### PR TITLE
python2to3, fix broken dependency while setup

### DIFF
--- a/pynag/__init__.py
+++ b/pynag/__init__.py
@@ -22,8 +22,12 @@ import sys
 import os
 import re
 from optparse import OptionParser
-from pynag import Plugins
-Plugin = Plugins.simple
+try:
+    from pynag import Plugins
+    Plugin = Plugins.simple
+except:
+    # when setup, import caused dependency error
+    pass
 
 
 __version__ = '0.9.1'


### PR DESCRIPTION
while setup, install `six` .

but , to execute setup, `six` required.